### PR TITLE
Timeout handling adjusted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ## [Unreleased][]
 
+### Changed
+
+- Timeout behavior changed
+  - "desktop.FindFirstByXPath(xpath)" needs a few seconds to finds element so retry which was default 
+    10 times would break testing duration.
+  - Retry is removed and sleep function can be disabled now with a "timeout=0"
+  - If a timeout is set then this function will now waits the amount of time and check once and do not check 
+    by a periodic timer anymore
+  - Default timeout is still '1000 ms' to wait for an recheck if element could not be found
+
 ## [Release][1.6.5] [1.6.5][1.6.4-1.6.5] - 2021-08-28
 
 ### Changed

--- a/src/FlaUILibrary/flaui/module/element.py
+++ b/src/FlaUILibrary/flaui/module/element.py
@@ -197,7 +197,7 @@ class Element(ModuleInterface):
 
     def _get_element(self, xpath: str):
         """
-        Try to get element from xpath.
+        Try to get element.
 
         Args:
             xpath (string): XPath identifier from element.
@@ -206,23 +206,28 @@ class Element(ModuleInterface):
             FlaUiError: If node could not be found by xpath.
         """
         try:
-            retry = 0
-            max_retry = 10
-            timeout = self._timeout / (1000 * max_retry)
+            component = self._get_element_by_xpath(xpath)
+            if not component and self._timeout > 0:
+                time.sleep(self._timeout / 1000)
+                component = self._get_element_by_xpath(xpath)
 
-            while retry < max_retry:
-                desktop = self._automation.GetDesktop()
-                component = desktop.FindFirstByXPath(xpath)
-                if component:
-                    return component
-                if timeout > 0:
-                    time.sleep(timeout)
-                retry = retry + 1
+            if component:
+                return component
 
             raise FlaUiError(FlaUiError.XPathNotFound.format(xpath))
 
         except CSharpException:
             raise FlaUiError(FlaUiError.XPathNotFound.format(xpath)) from None
+
+    def _get_element_by_xpath(self, xpath: str):
+        """
+        Try to get element from xpath by desktop.
+
+        Args:
+            xpath (string): XPath identifier from element.
+        """
+        desktop = self._automation.GetDesktop()
+        return desktop.FindFirstByXPath(xpath)
 
     def _element_should_not_exist(self, xpath: str):
         """


### PR DESCRIPTION
Retry removed from timeout get element behaviour.
Timeout will wait once and call once if element exists after amount of time.
FindFirstElement needs a few seconds to index desktop so repeat function.