### PR TITLE
Multi application process handling implement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
 
 ### Changed
 
+#### New Element Should Exist or Element Should Not Exist Syntax
+
 - Keyword behaviour changed for Element Should Exist and Element Should Not Exist
   - Keywords contains now a use_exceptions flag to decide if an exception should be called or a return value.
     - Exception handling will be used in general to check if a ui element is closing or opened
@@ -25,25 +27,24 @@ This document follows the conventions laid out in [Keep a CHANGELOG][].
       - Wait Until Keyword Succeeds combination does not work anymore to check if an ui is displaying after amount of time
       - Returns now always True or False
 
-#### Old Syntax
+#### Old Style
 ```
 # This throws a flaui exception and stop test exeuction
 Element Should Exist  /WRONG/XPATH
 ```
 
-#### New Syntax
-
 - You can now decide to use the old syntax or new style by using the flag parameter use_exceptions.
 - This is by default ${TRUE} to avoid this breaks for checkups if a ui element is displaying delayed.
 
+#### New Style
 ```
 # This throws a flaui exception and stop test exeuction
 Element Should Exist      /WRONG/XPATH
 Element Should Not Exist  /VALID_XPATH
 
 # Usage with Wait Until Keyword Succeeds
-Wait Until Keyword Succeeds  Element Should Exist      /VALID_XPATH
-Wait Until Keyword Succeeds  Element Should Not Exist  /VALID_XPATH
+Wait Until Keyword Succeeds 5x  1s  Element Should Exist      /VALID_XPATH
+Wait Until Keyword Succeeds 5x  1s  Element Should Not Exist  /VALID_XPATH
 
 # If you want to check the return value by your own syntax.
 # Wait Until Keyword Succeeds will not work anymore because this keyword will always Return True or False now
@@ -51,8 +52,35 @@ ${RESULT}  Element Should Exist  /VALID_XPATH  ${FALSE}
 ${RESULT}  Element Should Not Exist  /WRONG/XPATH  ${FALSE}
 ```
 
+#### New Wait Until Element Is Hidden Syntax
+
 - Wait Until Element Is Hidden does not check anymore if element exists
   - No xpath not found exception is called anymore to avoid break tests
+
+#### New Application Syntax
+
+- Application keyword modified for multi gui process handling
+  - Launch Application, Launch Application With Args, Attach Application By Name or PID returns always a PID.
+  - PID must be used by Close Application now to stop correct application  ${PID}
+  - Old syntax stores only last started application
+    - It was not possible to handle multiple application processes if needed
+  - Unnecessary Keywords removed Attach To Application By Pid and Name
+  - If application with a wrong pid will be tried to close a FlaUI exception will be called
+  - Caller has always to close all applications by Teardown or Keywords
+
+```
+# Launch multiple applications
+${PID_A}  Launch Application  APPLICATION_A
+${PID_B}  Launch Application  APPLICATION_B
+${PID_C}  Launch Application  APPLICATION_C
+${PID_D}  Attach To Process By PID  ${PID}
+
+# Close applications
+Close Application  ${PID_C}
+Close Application  ${PID_A}
+Close Application  ${PID_B}
+Close Application  ${PID_D}
+```
 
 ## [Release][1.6.6] [1.6.6][1.6.5-1.6.6] - 2021-09-01
 

--- a/atests/Application.robot
+++ b/atests/Application.robot
@@ -9,28 +9,29 @@ Resource        util/XPath.robot
 
 *** Test Cases ***
 Attach Application By Name
-    [Setup]    Start Application
-    [Teardown]  Stop Application
-    Attach Application By Name   ${TEST_APP}
+    [Setup]     Start Application
+    [Teardown]  Stop Application  ${PID}
+    ${PID}  Attach Application By Name   ${TEST_APP}
+    Should Not Be Equal As Integers  ${PID}  0
 
 Attach Application By PID
-    [Teardown]  Stop Application
+    [Teardown]  Stop Application  ${PID}
     ${PID}  Launch Application  ${TEST_APP}
     Wait Until Keyword Succeeds  10x  200ms  Element Should Exist  ${MAIN_WINDOW}
     Should Not Be Equal As Integers  ${PID}  0
     Attach Application By PID    ${PID}
 
 Close Application If Application Is Attached
-    [Setup]    Start Application
-    Close Application
+    ${PID}  Start Application
+    Close Application  ${PID}
 
 Launch Application
-    [Teardown]  Stop Application
+    [Teardown]  Stop Application  ${PID}
     ${PID}  Launch Application  ${TEST_APP}
     Should Not Be Equal As Integers  ${PID}  0
 
 Launch Application With Arguments
-    [Teardown]  Stop Application
+    [Teardown]  Stop Application  ${PID}
     ${PID}  Launch Application With Args  ${TEST_APP_NOTIFIER}  Hello- World
     Should Not Be Equal As Integers  ${PID}  0
     Name Contains Text  Hello-World   /Window[@Name='Hello-World']

--- a/atests/Checkbox.robot
+++ b/atests/Checkbox.robot
@@ -7,8 +7,8 @@ Library         StringFormat
 Resource        util/Common.robot
 Resource        util/XPath.robot
 
-Suite Setup      Start Application
-Suite Teardown   Stop Application
+Suite Setup      Init Main Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Variables ***
 ${XPATH_CHECKBOX}  ${MAIN_WINDOW_SIMPLE_CONTROLS}/CheckBox[@AutomationId='SimpleCheckBox']

--- a/atests/Combobox.robot
+++ b/atests/Combobox.robot
@@ -9,8 +9,8 @@ Resource        util/Common.robot
 Resource        util/Error.robot
 Resource        util/XPath.robot
 
-Suite Setup      Start Application
-Suite Teardown   Stop Application
+Suite Setup      Init Main Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Variables ***
 ${XPATH_COMBO_BOX}          ${MAIN_WINDOW_SIMPLE_CONTROLS}/ComboBox[@AutomationId='NonEditableCombo']

--- a/atests/Debug.robot
+++ b/atests/Debug.robot
@@ -8,8 +8,8 @@ Library         StringFormat
 Resource        util/Common.robot
 Resource        util/XPath.robot
 
-Suite Setup      Start Application
-Suite Teardown   Stop Application
+Suite Setup      Init Main Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Test Cases ***
 Get Childs From Element

--- a/atests/Element.robot
+++ b/atests/Element.robot
@@ -10,8 +10,8 @@ Resource        util/Common.robot
 Resource        util/Error.robot
 Resource        util/XPath.robot
 
-Suite Setup      Start Application
-Suite Teardown   Stop Application
+Suite Setup      Init Main Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Variables ***
 ${XPATH_ELEMENT}            ${MAIN_WINDOW_SIMPLE_CONTROLS}/Text[@Name='Test Label']
@@ -87,7 +87,7 @@ Element Should Not Be Visible Error
     Should Be Equal As Strings  ${EXP_ERR_MSG}  ${ERR_MSG}
 
 Wait Until Element Is Hidden
-    [Setup]    Start Application    ${TEST_APP_NOTIFIER}  ${MAIN_WINDOW_NOTIFIER}
+    ${PID}  Start Application       ${TEST_APP_NOTIFIER}  ${MAIN_WINDOW_NOTIFIER}
     Wait Until Element Is Hidden    ${MAIN_WINDOW_NOTIFIER}
     Element Should Not Exist        ${MAIN_WINDOW_NOTIFIER}
 
@@ -115,8 +115,8 @@ Wait Until Element Is Hidden Timeout Is Reached By Wrong Number
     Should Be Equal As Strings  ${EXP_ERR_MSG}  ${ERR_MSG}
 
 Wait Until Element Is Visible
-    [Setup]    Start Application With Args  ${TEST_APP_NOTIFIER}  ${MAIN_WINDOW_NOTIFIER}  Delayed
-    [Teardown]  Stop Application  ${MAIN_WINDOW_NOTIFIER}
+    [Teardown]  Stop Application  ${PID}  ${MAIN_WINDOW_NOTIFIER}
+    ${PID}  Start Application With Args  ${TEST_APP_NOTIFIER}  ${MAIN_WINDOW_NOTIFIER}  Delayed
     Wait Until Element Is Visible    ${MAIN_WINDOW_NOTIFIER}
     Element Should Exist             ${MAIN_WINDOW_NOTIFIER}
 

--- a/atests/ErrorHandling.robot
+++ b/atests/ErrorHandling.robot
@@ -17,7 +17,7 @@ ${EXP_VALUE_INPUT_TEXT}            Type text
 Attach Application By Name        Attach Application By Name  ${EXP_ERR_MSG_APP_NAME_NOT_FOUND}  ${XPATH_NOT_EXISTS}
 Attach Application By PID         Attach Application By PID  ${EXP_ERR_MSG_VALUE_SHOULD_BE_A_NUMBER}  ${XPATH_NOT_EXISTS}
 Click                             Click  ${EXP_ERR_MSG_XPATH_NOT_FOUND}  ${XPATH_NOT_EXISTS}
-Close Application                 Close Application  ${EXP_ERR_MSG_APP_NOT_ATTACHED}
+Close Application                 Close Application  ${EXP_ERR_MSG_APP_NOT_ATTACHED}  ${0}
 Close Window                      Close Window  ${EXP_ERR_MSG_XPATH_NOT_FOUND}  ${XPATH_NOT_EXISTS}
 Combobox Should Contain           Combobox Should Contain  ${EXP_ERR_MSG_XPATH_NOT_FOUND}  ${XPATH_NOT_EXISTS}  Item 3
 Collapse TreeItem                 Collapse TreeItem  ${EXP_ERR_MSG_XPATH_NOT_FOUND}  ${XPATH_NOT_EXISTS}  No Such Item

--- a/atests/Grid.robot
+++ b/atests/Grid.robot
@@ -9,9 +9,9 @@ Resource        util/Common.robot
 Resource        util/Error.robot
 Resource        util/XPath.robot
 
-Suite Setup      Run Keywords  Start Application
+Suite Setup      Run Keywords  Init Main Application
 ...              AND           Open Complex Tab
-Suite Teardown   Stop Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Variables ***
 ${XPATH_GRID_VIEW}  ${MAIN_WINDOW_COMPLEX_CONTROLS}/Pane/Group[@Name='Grid']/DataGrid[@AutomationId='dataGridView']

--- a/atests/Keyboard.robot
+++ b/atests/Keyboard.robot
@@ -9,8 +9,8 @@ Resource        util/Common.robot
 Resource        util/Error.robot
 Resource        util/XPath.robot
 
-Suite Setup      Start Application
-Suite Teardown   Stop Application
+Suite Setup      Init Main Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 Test Teardown    Reset Textbox
 
 *** Variables ***

--- a/atests/Listbox.robot
+++ b/atests/Listbox.robot
@@ -9,8 +9,8 @@ Resource        util/Common.robot
 Resource        util/Error.robot
 Resource        util/XPath.robot
 
-Suite Setup      Start Application
-Suite Teardown   Stop Application
+Suite Setup      Init Main Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Variables ***
 ${XPATH_LISTBOX}  ${MAIN_WINDOW_SIMPLE_CONTROLS}/List[@AutomationId='ListBox']

--- a/atests/Mouse.robot
+++ b/atests/Mouse.robot
@@ -8,8 +8,8 @@ Resource        util/Common.robot
 Resource        util/Error.robot
 Resource        util/XPath.robot
 
-Suite Setup      Start Application
-Suite Teardown   Stop Application
+Suite Setup      Init Main Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Variables ***
 ${EXPECTED_CONTEXT_MENU}   ${MAIN_WINDOW}/Window/Menu

--- a/atests/RadioButton.robot
+++ b/atests/RadioButton.robot
@@ -8,8 +8,8 @@ Library         StringFormat
 Resource        util/Common.robot
 Resource        util/XPath.robot
 
-Suite Setup      Start Application
-Suite Teardown   Stop Application
+Suite Setup      Init Main Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Variables ***
 ${XPATH_RADIO_BUTTON_ONE}  ${MAIN_WINDOW_SIMPLE_CONTROLS}/RadioButton[@AutomationId='RadioButton1']

--- a/atests/Screenshot.robot
+++ b/atests/Screenshot.robot
@@ -11,7 +11,7 @@ Resource        util/Error.robot
 Resource        util/XPath.robot
 
 *** Variables ***
-${SCREENSHOT_FOLDER} =  screenshots
+${SCREENSHOT_FOLDER}  screenshots
 
 *** Test Cases ***
 Take No Screenshot If Module Is Disabled

--- a/atests/Tab.robot
+++ b/atests/Tab.robot
@@ -9,8 +9,8 @@ Resource        util/Common.robot
 Resource        util/Error.robot
 Resource        util/XPath.robot
 
-Suite Setup      Start Application
-Suite Teardown   Stop Application
+Suite Setup      Init Main Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Variables ***
 ${XPATH_TAB}                                   ${MAIN_WINDOW}/Tab

--- a/atests/Textbox.robot
+++ b/atests/Textbox.robot
@@ -8,8 +8,8 @@ Library         StringFormat
 Resource        util/Common.robot
 Resource        util/XPath.robot
 
-Suite Setup      Start Application
-Suite Teardown   Stop Application
+Suite Setup      Init Main Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Variables ***
 ${XPATH_EDIT_BOX}          ${MAIN_WINDOW_SIMPLE_CONTROLS}/Edit[@AutomationId='TextBox']

--- a/atests/Tree.robot
+++ b/atests/Tree.robot
@@ -9,9 +9,9 @@ Resource        util/Common.robot
 Resource        util/Error.robot
 Resource        util/XPath.robot
 
-Suite Setup      Run Keywords  Start Application
+Suite Setup      Run Keywords  Init Main Application
 ...              AND           Open Complex Tab
-Suite Teardown   Stop Application
+Suite Teardown   Stop Application  ${MAIN_PID}
 
 *** Variables ***
 ${XPATH_TREE}  ${MAIN_WINDOW_COMPLEX_CONTROLS}/Pane/Group/Tree[@AutomationId='treeView1']

--- a/atests/Window.robot
+++ b/atests/Window.robot
@@ -13,6 +13,4 @@ Resource        util/XPath.robot
 Close Window
     Start Application
     Close Window    ${MAIN_WINDOW}
-    ${EXP_ERR_MSG}  Format String  ${EXP_ERR_MSG_XPATH_NOT_FOUND}  ${MAIN_WINDOW}
-    ${ERR_MSG}      Run Keyword And Expect Error  *  Element Should Exist  ${MAIN_WINDOW}
-    Should Be Equal As Strings  ${EXP_ERR_MSG}  ${ERR_MSG}
+    Wait Until Element Is Hidden  ${MAIN_WINDOW}

--- a/atests/util/Common.robot
+++ b/atests/util/Common.robot
@@ -5,29 +5,30 @@ ${TEST_APP}                                        apps\\WpfApplication
 ${TEST_APP_NOTIFIER}                               apps\\Notifier
 
 *** Keywords ***
-Close Window Application
-    [Arguments]   ${xpath}=${MAIN_WINDOW}
-    Run Keyword and Ignore Error  Close Application
-    Run Keyword and Ignore Error  Close Window  ${xpath}
-    Wait Until Keyword Succeeds  5x  100ms  Element Should Not Exist  ${xpath}
+Init Main Application
+  ${PID}  Start Application
+  Set Global Variable  ${MAIN_PID}  ${PID}
 
 Stop Application
-    [Arguments]   ${xpath}=${MAIN_WINDOW}
-    Wait Until Keyword Succeeds  5x  1s  Close Window Application  ${xpath}
+    [Arguments]  ${pid}=${INTERNAL_PID}  ${xpath}=${MAIN_WINDOW}
+    Close Application  ${pid}
+    Wait Until Element Is Hidden  ${xpath}
 
 Start Application
     [Arguments]   ${application}=${TEST_APP}  ${xpath}=${MAIN_WINDOW}
     ${PID}  Launch Application  ${application}
     Should Not Be Equal As Integers  ${PID}  0
-    Wait Until Keyword Succeeds  10x  200ms  Element Should Exist  ${xpath}
+    Wait Until Element Is Visible  ${xpath}
     Focus  ${xpath}
+    [Return]  ${PID}
 
 Start Application With Args
     [Arguments]   ${application}=${TEST_APP}  ${xpath}=${MAIN_WINDOW}  ${arguments}=${EXP_WINDOW_TITLE}
     ${PID}  Launch Application With Args  ${application}  ${arguments}
     Should Not Be Equal As Integers  ${PID}  0
-    Wait Until Keyword Succeeds  10x  200ms  Element Should Exist  ${xpath}
+    Wait Until Element Is Visible  ${xpath}
     Focus  ${xpath}
+    [Return]  ${PID}
 
 Open Complex Tab
     ${XPATH_TAB}                Set Variable  ${MAIN_WINDOW}/Tab

--- a/src/FlaUILibrary/keywords/application.py
+++ b/src/FlaUILibrary/keywords/application.py
@@ -18,7 +18,7 @@ class ApplicationKeywords:
     @keyword
     def attach_application_by_name(self, name, msg=None):
         """
-        Attach to an running application by name.
+        Attach to a running application by name.
 
         If application with name not exists an error message will be thrown.
 
@@ -28,17 +28,20 @@ class ApplicationKeywords:
         | msg        | string | Custom error message   |
 
         Examples:
-        | Attach Application By Name  <APPLICATION>                     |
-        | Attach Application By Name  <APPLICATION>  You shall not pass |
+        | ${pid}  Attach Application By Name  <APPLICATION>                     |
+        | ${pid}  Attach Application By Name  <APPLICATION>  You shall not pass |
+
+        Returns:
+        | Process id from attached process if successfully |
         """
-        self._module.action(Application.Action.ATTACH_APPLICATION_BY_NAME,
-                            Application.create_value_container(name=name, msg=msg),
-                            msg)
+        return self._module.action(Application.Action.ATTACH_APPLICATION_BY_NAME,
+                                   Application.create_value_container(name=name, msg=msg),
+                                   msg)
 
     @keyword
     def attach_application_by_pid(self, pid, msg=None):
         """
-        Attach to an running application by pid.
+        Attach to a running application by pid.
 
         If application with pid not exists an error message will be thrown.
 
@@ -48,16 +51,19 @@ class ApplicationKeywords:
         | msg        | string | Custom error message         |
 
         Examples:
-        | Attach Application By PID  <PID_NUMBER>                     |
-        | Attach Application By PID  <PID_NUMBER>  You shall not pass |
+        | ${pid}  Attach Application By PID  <PID_NUMBER>                     |
+        | ${pid}  Attach Application By PID  <PID_NUMBER>  You shall not pass |
+
+        Returns:
+        | Process id from attached process if successfully |
 
         """
-        self._module.action(Application.Action.ATTACH_APPLICATION_BY_PID,
-                            Application.create_value_container(pid=pid, msg=msg),
-                            msg)
+        return self._module.action(Application.Action.ATTACH_APPLICATION_BY_PID,
+                                   Application.create_value_container(pid=pid, msg=msg),
+                                   msg)
 
     @keyword
-    def close_application(self, msg=None):
+    def close_application(self, pid, msg=None):
         """
         Closes the attached application.
 
@@ -65,15 +71,16 @@ class ApplicationKeywords:
 
         Arguments:
         | Argument   | Type   | Description          |
+        | pid        | int    | Process id to close  |
         | msg        | string | Custom error message |
 
         Examples:
-        | Launch Application  <APPLICATION> |
-        | Close Application                 |
+        | $[pid}  Launch Application  <APPLICATION> |
+        | Close Application  $[pid}                 |
 
         """
         self._module.action(Application.Action.EXIT_APPLICATION,
-                            Application.create_value_container(msg=msg),
+                            Application.create_value_container(pid=pid, msg=msg),
                             msg=msg)
 
     @keyword
@@ -89,7 +96,7 @@ class ApplicationKeywords:
         | msg         | string | Custom error message                               |
 
         Examples:
-        | Launch Application  <APPLICATION> |
+        | ${pid}  Launch Application  <APPLICATION> |
 
         Returns:
         | Process id from started process if successfully |
@@ -113,7 +120,7 @@ class ApplicationKeywords:
         | msg         | string | Custom error message                               |
 
         Examples:
-        | Launch Application  <APPLICATION>  <ARGUMENTS> |
+        | ${pid}  Launch Application  <APPLICATION>  <ARGUMENTS> |
 
         Returns:
         | Process id from started process if successfully |


### PR DESCRIPTION
#### New Wait Until Element Is Hidden Syntax

- Wait Until Element Is Hidden does not check anymore if element exists
  - No xpath not found exception is called anymore to avoid break tests

#### New Application Syntax

- Application keyword modified for multi gui process handling
  - Launch Application, Launch Application With Args, Attach Application By Name or PID returns always a PID.
  - PID must be used by Close Application now to stop correct application  ${PID}
  - Old syntax stores only last started application
    - It was not possible to handle multiple application processes if needed
  - Unnecessary Keywords removed Attach To Application By Pid and Name
  - If application with a wrong pid will be tried to close a FlaUI exception will be called
  - Caller has always to close all applications by Teardown or Keywords

```
# Launch multiple applications
${PID_A}  Launch Application  APPLICATION_A
${PID_B}  Launch Application  APPLICATION_B
${PID_C}  Launch Application  APPLICATION_C
${PID_D}  Attach To Process By PID  ${PID}

# Close applications
Close Application  ${PID_C}
Close Application  ${PID_A}
Close Application  ${PID_B}
Close Application  ${PID_D}
```