### PR TITLE
Update setup.py to allow package installation on Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open("./src/FlaUILibrary/version.py", "r") as fh:
     IGNORE, VERSION = VersionFile.split(" = ")
     VERSION = VERSION.replace("\"", "")
 
-with open("Readme.md", "r") as fh:
+with open("README.md", "r") as fh:
     LONG_DESCRIPTION = fh.read()
 
 with open("requirements.txt", "r") as f:


### PR DESCRIPTION
Prevent a crash when installing the package on Linux due to differences in how case sensitivity is treated between Linux and Windows 